### PR TITLE
Improve shipment and status by using active_hash #19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 # add
+gem 'active_hash'
 gem 'bootstrap-sass', '3.3.7'
 gem 'bootstrap-will_paginate', '1.0.0'
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (5.1.6)
       activesupport (= 5.1.6)
       globalid (>= 0.3.6)
@@ -43,7 +45,7 @@ GEM
     ansi (1.5.0)
     arel (8.0.0)
     ast (2.4.1)
-    autoprefixer-rails (9.8.5)
+    autoprefixer-rails (9.8.6.1)
       execjs
     bcrypt (3.1.15)
     bindex (0.8.1)
@@ -113,7 +115,7 @@ GEM
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lumberjack (1.2.6)
+    lumberjack (1.2.7)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
@@ -289,6 +291,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bcrypt (~> 3.1.7)
   bootstrap-sass (= 3.3.7)
   bootstrap-will_paginate (= 1.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  include ApplicationHelper
   include SessionsHelper
   include ConstructionsHelper
   include OrdersHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,51 @@ module ApplicationHelper
       page_title + " | " + base_title
     end
   end
+
+  def set_time(params, period)
+    if params["#{period}_at_date"].present?
+      count = 1
+      period_date = params["#{period}_at_date"].split("-")
+      period_date.each do |pd|
+        params["#{period}_at(#{count}i)"] = pd
+        count += 1
+      end
+    end
+  end
+
+  def reset_time(period)
+    if params["#{period}_at_date"].blank?
+      3.times do |n|
+        n += 1
+        params["#{period}_at(#{n}i)"] = ""
+      end
+    end
+  end
+
+  # sort
+  def sort_asc(column_to_be_sorted, search_params = nil)
+    opts = { :column => column_to_be_sorted, :direction => "asc" }
+    opts.merge!(search_params) if search_params.present?
+    link_to "▲", opts
+  end
+
+  def sort_desc(column_to_be_sorted, search_params = nil)
+    opts = { :column => column_to_be_sorted, :direction => "desc" }
+    opts.merge!(search_params) if search_params.present?
+    link_to "▼", opts
+  end
+
+  def sort_direction
+    %W(asc desc).include?(params[:direction]) ? params[:direction] : "asc"
+  end
+
+#            <!-- TODO リファクタリング -->
+#  def send_to_csv(name, parameter, search_params, sort_column, sort_direction)
+#    if params[:export_csv]
+#      csv_data = parameter.class.search(search_params).order(sort_column + ' ' + sort_direction)
+#      name = name
+#      send_data to_csv_name(csv_data), filename: "#{Time.current.strftime('%Y%m%d')}オーダー一覧.csv"
+#    end
+#  end
+
 end

--- a/app/helpers/constructions_helper.rb
+++ b/app/helpers/constructions_helper.rb
@@ -1,40 +1,5 @@
 module ConstructionsHelper
 require 'csv'
-  def set_time(params, period)
-    if params["#{period}_at_date"].present?
-      count = 1
-      period_date = params["#{period}_at_date"].split("-")
-      period_date.each do |pd|
-        params["#{period}_at(#{count}i)"] = pd
-        count += 1
-      end
-    end
-  end
-
-  # sort
-  def sort_asc(column_to_be_sorted, search_params = nil)
-    opts = { :column => column_to_be_sorted, :direction => "asc" }
-    opts.merge!(search_params) if search_params.present?
-    link_to "▲", opts
-  end
-
-  def sort_desc(column_to_be_sorted, search_params = nil)
-    opts = { :column => column_to_be_sorted, :direction => "desc" }
-    opts.merge!(search_params) if search_params.present?
-    link_to "▼", opts
-  end
-
-  def sort_direction
-    %W(asc desc).include?(params[:direction]) ? params[:direction] : "asc"
-  end
-
-  def reset_params(period)
-    3.times do |n|
-      n += 1
-      params["#{period}_at(#{n}i)"] = ""
-    end
-  end
-
   # export to csv
   def to_csv_construction(constructions)
     CSV.generate do |csv|

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,5 +1,6 @@
 module OrdersHelper
-
+require 'csv'
+  # export to csv
   def to_csv_order(orders)
     CSV.generate do |csv|
       columns_ja = %w(No. 船名 会社名 入出荷 対象設備 油種 数量 単位 担当者名 荷役作業日時)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -45,7 +45,7 @@ class Order < ApplicationRecord
         if c.start_at < arrive_at && arrive_at < c.end_at
           errors.add(:facility_id, "：#{Facility.find(facility_id).name}の
                                    #{arrive_at.strftime("%Y/%m/%d/%H:%M")}
-                                   は工事(#{c.name}, 他#{constructions.count - 1}件)による出荷制約があります")
+                                   は工事(#{c.name})による出荷制約があります")
         end
       end
     end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -1,0 +1,3 @@
+class Shipment < ActiveHash::Base
+  self.data = [{ id: 1, name: '入荷' }, { id: 2, name: '出荷' }]
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,4 @@
+class Status < ActiveHash::Base
+  self.data = [{ id: 1, name: '実行検討中' }, { id: 2, name: '工事準備中' },
+               { id: 3, name: '工事中' }, { id: 4, name: '工事完了' }]
+end

--- a/app/views/constructions/index.html.erb
+++ b/app/views/constructions/index.html.erb
@@ -1,14 +1,9 @@
 <% provide(:title, '工事一覧') %>
-<script>
-  function btn_click() {
-    window.location.delay(1000).reload();
-  };
-  });
-</script>
+
 <div class="container">
   <h1 class="title title-const-index">工事一覧</h1>
   <div class="constructions-container">
-    <%= form_with url: constructions_path, method: :get, local: true do |f| %>
+    <%= form_with url: constructions_search_path, method: :get, local: true do |f| %>
     <table class="table table-hover">
       <thead>
         <th>工事名</th>
@@ -17,12 +12,12 @@
             <!-- TODO リファクタリング -->
             <option value=""></option>
             <% @status.each do |s| %>
-            <% if s == @search_params[:status] %>
-            <option value="<%= s %>" selected>
+            <% if s.id == @search_params[:status].to_i %>
+            <option value="<%= s.id %>" selected>
               <% else %>
-            <option value="<%= s %>">
+            <option value="<%= s.id %>">
               <% end %>
-              <%= s %>
+              <%= s.name %>
             </option>
             <% end %>
           </select>
@@ -86,7 +81,7 @@
         </th>
         <th>
           <!-- TODO リロードさせる -->
-          <button onclick="btn_click()" name="export_csv" type="submit" class="btn-search csv" id="download-csv">
+          <button name="export_csv" type="submit" class="btn-search csv">
             CSV出力
           </button>
           <br> <br>
@@ -98,7 +93,7 @@
       <% @construction.each do |construction| %>
       <tr>
         <td style="width:28%"><%= link_to construction.name, construction %></td>
-        <td style="width:12%"><%= construction.status %></td>
+        <td style="width:12%"><%= @status.find(construction.status).name %></td>
         <td style="width:15%">
           <% if construction.facility_id.present? %>
           <%= construction.facility.name%>
@@ -122,5 +117,5 @@
   </table>
   <% end %>
 
-  <%= will_paginate @construction, previous_label: '&#8592; &nbsp;前', next_label: '次 &#8594;'%>
+  <%= will_paginate @construction, previous_label: '← 前', next_label: '次 →'%>
 </div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,15 +1,9 @@
 <% provide(:title, 'オーダー一覧') %>
-<script>
-  function btn_click() {
-    window.location.delay(1000).reload();
-  };
-  });
-</script>
 
 <div class="container">
   <h1 class="title title-const-index">オーダー一覧</h1>
   <div class="orders-container">
-    <%= form_with url: orders_path, method: :get, local: true do |f| %>
+    <%= form_with url: orders_search_path, method: :get, local: true do |f| %>
     <table class="table table-hover">
       <thead>
         <th>
@@ -54,13 +48,13 @@
           <select name="shipment" class="index-search">
             <!-- TODO リファクタリング -->
             <option value=""></option>
-            <% ["入荷", "出荷"].each do |o| %>
-            <% if o == @search_params[:shipment] %>
-            <option value="<%= o %>" selected>
+            <% @shipment.each do |s| %>
+            <% if s.id == @search_params[:shipment].to_i %>
+            <option value="<%= s.id %>" selected>
               <% else %>
-            <option value="<%= o %>">
+            <option value="<%= s.id %>">
               <% end %>
-              <%= o %>
+              <%= s.name %>
             </option>
             <% end %>
           </select>
@@ -108,7 +102,7 @@
           <%= sort_desc('oil_id', @search_params) %>
         </th>
         <th>
-          <input type="date" name="arrive_at_date" class="index-search-time">
+          <input type="date" value="<%= @search_params[:arrive_at_date] %>" name=" arrive_at_date" class="index-search-time">
           <%= f.date_select :arrive_at, discard_year: true, discard_month: true, discard_day: true %>
           <br>
           荷役作業日時
@@ -117,7 +111,7 @@
         </th>
         <th>
           <!-- TODO リロードさせる -->
-          <button onclick="btn_click()" name="export_csv" type="submit" class="btn-search csv" id="download-csv">
+          <button name="export_csv" type="submit" class="btn-search csv">
             CSV出力
           </button>
           <br> <br>
@@ -133,7 +127,7 @@
       <tr>
         <td style="width:15%"><%= link_to order.name, order %></td>
         <td style="width:15%"><%= order.company_name %></td>
-        <td style="width:10%"><%= order.shipment %></td>
+        <td style="width:10%"><%= @shipment.find(order.shipment).name %></td>
         <td style="width:12%"><%= order.facility.name%></td>
         <td style="width:14%"><%= order.oil.name %></td>
         <td style="width:10%">
@@ -147,5 +141,5 @@
   </table>
   <% end %>
 
-  <%= will_paginate @order, previous_label: '&#8592; &nbsp;前', next_label: '次 &#8594;'%>
+  <%= will_paginate @order, previous_label: '← 前', next_label: '次 →'%>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,6 @@ module ScheduleApp
 
     config.time_zone = 'Tokyo'
     config.action_view.embed_authenticity_token_in_remote_forms = true
-
+    config.action_view.automatically_disable_submit_tag = false
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
   root   'home#top'
 
-  get    '/:category_id/order/oil', to: 'orders#oil', as: 'order_oil'
+  get    '/orders/search', to: 'orders#search', as: 'orders_search'
   get    '/:category_id/order', to: 'orders#new', as: 'new_order'
   post   '/:category_id/order', to: 'orders#create'
   resources :orders, except: [:new, :create]
 
+  get    '/constructions/search', to: 'constructions#search', as: 'constructions_search'
   get    '/:category_id/construction', to: 'constructions#new', as: 'new_construction'
   post   '/:category_id/construction', to: 'constructions#create'
   resources :constructions, except: [:new, :create]

--- a/db/migrate/20200713085756_create_constructions.rb
+++ b/db/migrate/20200713085756_create_constructions.rb
@@ -2,8 +2,8 @@ class CreateConstructions < ActiveRecord::Migration[5.1]
   def change
     create_table :constructions do |t|
       t.string     :name
-      t.string     :status
       t.text       :notice
+      t.integer    :status
       t.references :facility, foreign_key: true
       t.references :oil,      foreign_key: true
       t.references :category, foreign_key: true

--- a/db/migrate/20200727060542_create_orders.rb
+++ b/db/migrate/20200727060542_create_orders.rb
@@ -2,9 +2,9 @@ class CreateOrders < ActiveRecord::Migration[5.1]
   def change
     create_table :orders do |t|
       t.string     :name
-      t.string     :shipment
       t.string     :company_name
       t.string     :unit
+      t.integer    :shipment
       t.integer    :quantity
       t.references :facility, foreign_key: true
       t.references :oil,      foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,8 +20,8 @@ ActiveRecord::Schema.define(version: 20200727060542) do
 
   create_table "constructions", force: :cascade do |t|
     t.string "name"
-    t.string "status"
     t.text "notice"
+    t.integer "status"
     t.integer "facility_id"
     t.integer "oil_id"
     t.integer "category_id"
@@ -60,9 +60,9 @@ ActiveRecord::Schema.define(version: 20200727060542) do
 
   create_table "orders", force: :cascade do |t|
     t.string "name"
-    t.string "shipment"
     t.string "company_name"
     t.string "unit"
+    t.integer "shipment"
     t.integer "quantity"
     t.integer "facility_id"
     t.integer "oil_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,7 +57,7 @@ notices = ["工程内で制約日程は調整可能", "工事中は桟橋クロ�
   start_at = Time.now.midnight.since(mm.month + d.days + h.hour)
   end_at   = start_at.since(d.days + dh.hour)
   user     = User.find(rand(1..19))
-  status = m < 3 ? "工事準備中" : "実行検討中"
+  status = m < 3 ? 1 : 2
   notice = notices[rand(0..2)] if m > 4
   facility = Facility.find(rand(1..Facility.count-1))
   oil = facility.oils[rand(0..facility.oils.count-1)]
@@ -88,9 +88,9 @@ notices = ["工程内で制約日程は調整可能", "工事中は桟橋クロ�
     construction.update_attribute(:start_at, start_at)
     construction.update_attribute(:end_at, end_at)
     if end_at < Time.now
-      construction.update_attribute(:status, "工事完了")
+      construction.update_attribute(:status, 4)
     else
-      construction.update_attribute(:status, "工事中")
+      construction.update_attribute(:status, 3)
     end
   end
 end
@@ -106,7 +106,7 @@ end
   oil = facility.oils[rand(0..facility.oils.count-1)]
   facility_id = facility.id
   oil_id = oil.id
-  shipment = rand(1..100) % 2 == 0 && oil_id != 1 ? "入荷" : "出荷"
+  shipment = rand(1..100) % 2 == 0 && oil_id != 1 ? 1 : 2
   quantity = m * 100
   user_id = user.id
 
@@ -150,7 +150,7 @@ end
   oil = facility.oils[rand(0..facility.oils.count-1)]
   facility_id = facility.id
   oil_id = oil.id
-  shipment = rand(1..100) % 2 == 0 && oil_id != 1 ? "入荷" : "出荷"
+  shipment = rand(1..100) % 2 == 0 && oil_id != 1 ? 1 : 2
   quantity = m * 100
   user_id = user.id
 


### PR DESCRIPTION
why
定数配列をベタ打ちで定義しメンテナンス性が良くなかったため

what
・Construction ModelのstatusカラムをIntegerに変更
・Status Modelをactive hashで作成、定数配列定義
・Order ModelのshipmentカラムをIntegerに変更
・Shipment Modelをactive hashで作成、定数配列定義